### PR TITLE
Bugfix: Grouping logic does not look at year for "This month"

### DIFF
--- a/src/views/Chores/MyChores.jsx
+++ b/src/views/Chores/MyChores.jsx
@@ -119,10 +119,11 @@ const MyChores = () => {
           Overdue: [],
           Anytime: [],
         }
+        var now = new Date()
         chores.forEach(chore => {
           if (chore.nextDueDate === null) {
             groupRaw['Anytime'].push(chore)
-          } else if (new Date(chore.nextDueDate) < new Date()) {
+          } else if (new Date(chore.nextDueDate) < now) {
             groupRaw['Overdue'].push(chore)
           } else if (
             new Date(chore.nextDueDate).toDateString() ===
@@ -136,7 +137,8 @@ const MyChores = () => {
           ) {
             groupRaw['In a week'].push(chore)
           } else if (
-            new Date(chore.nextDueDate).getMonth() === new Date().getMonth()
+            new Date(chore.nextDueDate) <
+            new Date(now.getFullYear(), now.getMonth() + 1, 1)
           ) {
             groupRaw['This month'].push(chore)
           } else {


### PR DESCRIPTION
Simply put, here's a case in the UI that looks odd:
<img width="377" alt="image" src="https://github.com/user-attachments/assets/f5f61a70-52ac-4ace-8be5-970cc9412022" />

Changed the logic to check the start of the next month as a bound rather than compare equality